### PR TITLE
DSS Python 0.10.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,9 @@ build: false
 
 environment:
   matrix:
+    - PYTHON_VERSION: 3.9
+      TARGET_ARCH: "x64"
+      MINICONDA: C:\Miniconda3-x64
     - PYTHON_VERSION: 3.8
       TARGET_ARCH: "x64"
       MINICONDA: C:\Miniconda3-x64
@@ -17,9 +20,9 @@ environment:
     - PYTHON_VERSION: 3.5
       TARGET_ARCH: "x64"
       MINICONDA: C:\Miniconda3-x64
-    - PYTHON_VERSION: 2.7
-      TARGET_ARCH: "x64"
-      MINICONDA: C:\Miniconda-x64
+    - PYTHON_VERSION: 3.9
+      TARGET_ARCH: "x86"
+      MINICONDA: C:\Miniconda3
     - PYTHON_VERSION: 3.8
       TARGET_ARCH: "x86"
       MINICONDA: C:\Miniconda3
@@ -32,9 +35,6 @@ environment:
     - PYTHON_VERSION: 3.5
       TARGET_ARCH: "x86"
       MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 2.7
-      TARGET_ARCH: "x86"
-      MINICONDA: C:\Miniconda
 
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
@@ -43,8 +43,6 @@ install:
   - conda info -a
   - "conda create -q -n test-environment python=%PYTHON_VERSION% pandas matplotlib pytest"
   - activate test-environment
-  - pip install cffi
-  - pip install --pre dss-python
   - pip install -e .[extras]
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - os: osx
   include:
     - os: linux
+      env: TRAVIS_PYTHON_VERSION="3.9"
+    - os: linux
       env: TRAVIS_PYTHON_VERSION="3.8"
     - os: linux
       env: TRAVIS_PYTHON_VERSION="3.7"
@@ -12,8 +14,8 @@ matrix:
       env: TRAVIS_PYTHON_VERSION="3.6"
     - os: linux
       env: TRAVIS_PYTHON_VERSION="3.5"
-    - os: linux
-      env: TRAVIS_PYTHON_VERSION="2.7"
+    - os: osx
+      env: TRAVIS_PYTHON_VERSION="3.9"
     - os: osx
       env: TRAVIS_PYTHON_VERSION="3.8"
     - os: osx
@@ -22,8 +24,6 @@ matrix:
       env: TRAVIS_PYTHON_VERSION="3.6"
     - os: osx
       env: TRAVIS_PYTHON_VERSION="3.5"
-    - os: osx
-      env: TRAVIS_PYTHON_VERSION="2.7"
 install:
   # Install conda
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -41,8 +41,6 @@ install:
   - source activate test-env
   - pip install pytest-cov
   - pip install codecov
-  - pip install cffi
-  - pip install --pre dss-python
   - pip install -e '.[extras]'
 script:
   - make

--- a/opendssdirect/Bus.py
+++ b/opendssdirect/Bus.py
@@ -190,6 +190,16 @@ def LineList():
     return CheckForError(get_string_array(lib.Bus_Get_LineList))
 
 
+def AllPCEatBus():
+    """Returns an array with the names of all PCE connected to the active bus"""
+    return CheckForError(get_string_array(lib.Bus_Get_AllPCEatBus))
+
+
+def AllPDEatBus():
+    """Returns an array with the names of all PDE connected to the active bus"""
+    return CheckForError(get_string_array(lib.Bus_Get_AllPDEatBus))
+
+
 _columns = [
     "Coorddefined",
     "CplxSeqVoltages",
@@ -223,6 +233,8 @@ _columns = [
     "Y",
 ]
 __all__ = [
+    "AllPCEatBus",
+    "AllPDEatBus",
     "GetUniqueNodeNumber",
     "ZscRefresh",
     "Coorddefined",

--- a/opendssdirect/CktElement.py
+++ b/opendssdirect/CktElement.py
@@ -278,6 +278,11 @@ def SeqVoltages():
     return get_float64_array(lib.CktElement_Get_SeqVoltages)
 
 
+def TotalPowers():
+    """Returns the total powers (complex) at ALL terminals of the active circuit element."""
+    return get_float64_array(lib.CktElement_Get_TotalPowers)
+
+
 def Voltages():
     """(read-only) Complex array of voltages at terminals"""
     return get_float64_array(lib.CktElement_Get_Voltages)
@@ -333,6 +338,7 @@ _columns = [
     "SeqCurrents",
     "SeqPowers",
     "SeqVoltages",
+    "TotalPowers",
     "Voltages",
     "VoltagesMagAng",
     "YPrim",
@@ -341,6 +347,7 @@ _columns = [
     "AllVariableValues",
     "AllVariableNames",
 ]
+
 __all__ = [
     "Close",
     "Controller",
@@ -382,6 +389,7 @@ __all__ = [
     "SeqCurrents",
     "SeqPowers",
     "SeqVoltages",
+    "TotalPowers",
     "Voltages",
     "VoltagesMagAng",
     "YPrim",

--- a/opendssdirect/Meters.py
+++ b/opendssdirect/Meters.py
@@ -271,6 +271,10 @@ def Totals():
     """(read-only) Totals of all registers of all meters"""
     return get_float64_array(lib.Meters_Get_Totals)
 
+def ZonePCE():
+    """Returns the list of all PCE within the area covered by the energy meter"""
+    return CheckForError(get_string_array(lib.Meters_Get_ZonePCE))
+
 
 def Idx(*args):
     """
@@ -361,5 +365,6 @@ __all__ = [
     "SumBranchFltRates",
     "TotalCustomers",
     "Totals",
+    "ZonePCE",
     "Idx",
 ]

--- a/opendssdirect/_version.py
+++ b/opendssdirect/_version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     author_email="me@kdheepak.com",
     license="BSD-compatible",
     packages=find_packages(),
-    install_requires=["future", "six", "dss_python>=0.10.6,<0.11"],
+    install_requires=["future", "six", "dss_python==0.10.7"],
     extras_require={
         "extras": ["pandas", "matplotlib", "networkx"],
         "dev": [
@@ -76,11 +76,11 @@ setup(
         "License :: Other/Proprietary License",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     cmdclass={"develop": PostDevelopCommand},
 )

--- a/tests/test_opendssdirect.py
+++ b/tests/test_opendssdirect.py
@@ -430,6 +430,13 @@ def test_13Node_Bus(dss):
 
     # TODO: this should not be sorted, we should define the order of the results
     assert sorted(dss.YMatrix.getV()[2:]) == sorted(dss.Circuit.AllBusVolts())
+    
+    assert dss.Bus.AllPDEatBus() == ["Transformer.sub"]
+    assert dss.Bus.AllPCEatBus() == ["Vsource.source"]
+    
+    dss.Circuit.SetActiveBus("684")
+    assert dss.Bus.AllPDEatBus() == ['Line.671684', 'Line.684611', 'Line.684652']
+    assert dss.Bus.AllPCEatBus() == []
 
 
 def test_13Node_Circuit(dss):
@@ -1159,6 +1166,7 @@ def test_13Node_CktElement(dss):
         u"B0",
         u"Seasons",
         u"Ratings",
+        u"LineType",
         u"normamps",
         u"emergamps",
         u"faultrate",
@@ -1263,11 +1271,16 @@ def test_13Node_CktElement(dss):
     )
     assert dss.CktElement.Name() == u"Line.671692"
     assert dss.CktElement.NodeOrder() == [1, 2, 3, 1, 2, 3]
+    np.testing.assert_almost_equal(
+        dss.CktElement.TotalPowers(),
+        [1013.9070515856262, 19.023976609590814, -1013.9070425310053, -19.023976609590783],
+        decimal=5,
+    )
     assert dss.CktElement.NormalAmps() == 400.0
     assert dss.CktElement.NumConductors() == 3
     assert dss.CktElement.NumControls() == 0
     assert dss.CktElement.NumPhases() == 3
-    assert dss.CktElement.NumProperties() == 37
+    assert dss.CktElement.NumProperties() == 38
     assert dss.CktElement.NumTerminals() == 2
     assert dss.CktElement.OCPDevIndex() == 0
     assert dss.CktElement.OCPDevType() == 0
@@ -1584,6 +1597,7 @@ def test_13Node_Element(dss):
         u"B0",
         u"Seasons",
         u"Ratings",
+        u"LineType",
         u"normamps",
         u"emergamps",
         u"faultrate",
@@ -1594,7 +1608,7 @@ def test_13Node_Element(dss):
         u"like",
     ]
     assert dss.Element.Name() == u"Line.671692"
-    assert dss.Element.NumProperties() == 37
+    assert dss.Element.NumProperties() == 38
 
 
 def test_13Node_Executive(dss):
@@ -1604,8 +1618,8 @@ def test_13Node_Executive(dss):
         == u"Create a new object within the DSS. Object becomes the active object\nExample: New Line.line1 ..."
     )
     assert (
-        dss.Executive.NumCommands() == 114
-    )  # adjusted to the latest version on 2020-07-28
+        dss.Executive.NumCommands() == 118
+    )  # adjusted to the latest version on 2020-12-28
     assert (
         dss.Executive.NumOptions() == 115
     )  # adjusted to the latest version on 2020-07-28
@@ -1937,6 +1951,7 @@ def test_13Node_Meters(dss):
     assert dss.Meters.AllNames() == []
     assert dss.Meters.SampleAll() is None
     assert dss.Meters.SaveAll() is None
+    assert dss.Meters.ZonePCE() == []
 
 
 def test_13Node_Monitors(dss):
@@ -4774,7 +4789,7 @@ def test_storage_to_dataframe(dss):
             "duty": {"Storage.631": ""},
             "enabled": {"Storage.631": True},
             "kVA": {"Storage.631": "25"},
-            "kW": {"Storage.631": "-0.25"},
+            "kW": {"Storage.631": "0"},
             "kWhrated": {"Storage.631": "50"},
             "kWhstored": {"Storage.631": "50"},
             "kWrated": {"Storage.631": "25"},
@@ -4838,6 +4853,7 @@ def test_linegeometry_class_to_dataframe():
         "linegeometry.hc2_336_1neut_0mess": {
             "Seasons": "1",
             "Ratings": ["0"],
+            "LineType": "ug",
             "nconds": "4",
             "nphases": "3",
             "cond": "4",
@@ -5672,35 +5688,35 @@ def test_wiredata_class_to_dataframe():
 
     assert data == {
         "wiredata.acsr1/0": {
-            "Capradius": "-1",
+            "Capradius": "0.199",
             "Seasons": "1",
             "Ratings": ["-1"],
-            "GMRac": "0.0044600",
+            "GMRac": "0.00446",
             "GMRunits": "ft",
-            "Rac": "1.120000",
-            "Rdc": "-1",
+            "Rac": "1.12",
+            "Rdc": "1.09804",
             "Runits": "mi",
-            "diam": "0.3980000",
-            "emergamps": "-1",
+            "diam": "0.398",
+            "emergamps": "345",
             "like": "",
-            "normamps": "230.0000",
-            "radius": "-1",
+            "normamps": "230",
+            "radius": "0.199",
             "radunits": "in",
         },
         "wiredata.acsr336": {
-            "Capradius": "-1",
+            "Capradius": "0.3705",
             "Seasons": "1",
             "Ratings": ["-1"],
-            "GMRac": "0.0255000",
+            "GMRac": "0.0255",
             "GMRunits": "ft",
-            "Rac": "0.3060000",
-            "Rdc": "-1",
+            "Rac": "0.306",
+            "Rdc": "0.3",
             "Runits": "mi",
-            "diam": "0.7410000",
-            "emergamps": "-1",
+            "diam": "0.741",
+            "emergamps": "795",
             "like": "",
-            "normamps": "530.0000",
-            "radius": "-1",
+            "normamps": "530",
+            "radius": "0.3705",
             "radunits": "in",
         },
     }

--- a/tests/test_opendssdirect_no_ext_errors.py
+++ b/tests/test_opendssdirect_no_ext_errors.py
@@ -1160,6 +1160,7 @@ def test_13Node_CktElement(dss):
         u"B0",
         u"Seasons",
         u"Ratings",
+        u"LineType",
         u"normamps",
         u"emergamps",
         u"faultrate",
@@ -1268,7 +1269,7 @@ def test_13Node_CktElement(dss):
     assert dss.CktElement.NumConductors() == 3
     assert dss.CktElement.NumControls() == 0
     assert dss.CktElement.NumPhases() == 3
-    assert dss.CktElement.NumProperties() == 37
+    assert dss.CktElement.NumProperties() == 38
     assert dss.CktElement.NumTerminals() == 2
     assert dss.CktElement.OCPDevIndex() == 0
     assert dss.CktElement.OCPDevType() == 0
@@ -1585,6 +1586,7 @@ def test_13Node_Element(dss):
         u"B0",
         u"Seasons",
         u"Ratings",
+        u"LineType",
         u"normamps",
         u"emergamps",
         u"faultrate",
@@ -1595,7 +1597,7 @@ def test_13Node_Element(dss):
         u"like",
     ]
     assert dss.Element.Name() == u"Line.671692"
-    assert dss.Element.NumProperties() == 37
+    assert dss.Element.NumProperties() == 38
 
 
 def test_13Node_Executive(dss):
@@ -1605,8 +1607,8 @@ def test_13Node_Executive(dss):
         == u"Create a new object within the DSS. Object becomes the active object\nExample: New Line.line1 ..."
     )
     assert (
-        dss.Executive.NumCommands() == 114
-    )  # adjusted to the latest version on 2020-07-28
+        dss.Executive.NumCommands() == 118
+    )  # adjusted to the latest version on 2020-12-28
     assert (
         dss.Executive.NumOptions() == 115
     )  # adjusted to the latest version on 2020-07-28
@@ -5045,7 +5047,7 @@ def test_storage_to_dataframe(dss):
             "duty": {"Storage.631": ""},
             "enabled": {"Storage.631": True},
             "kVA": {"Storage.631": "25"},
-            "kW": {"Storage.631": "-0.25"},
+            "kW": {"Storage.631": "0"},
             "kWhrated": {"Storage.631": "50"},
             "kWhstored": {"Storage.631": "50"},
             "kWrated": {"Storage.631": "25"},
@@ -5110,6 +5112,7 @@ def test_linegeometry_class_to_dataframe():
         "linegeometry.hc2_336_1neut_0mess": {
             "Seasons": "1",
             "Ratings": ["0"],
+            "LineType": "ug",
             "nconds": "4",
             "nphases": "3",
             "cond": "4",
@@ -5944,35 +5947,35 @@ def test_wiredata_class_to_dataframe():
 
     assert data == {
         "wiredata.acsr1/0": {
-            "Capradius": "-1",
+            "Capradius": "0.199",
             "Seasons": "1",
             "Ratings": ["-1"],
-            "GMRac": "0.0044600",
+            "GMRac": "0.00446",
             "GMRunits": "ft",
-            "Rac": "1.120000",
-            "Rdc": "-1",
+            "Rac": "1.12",
+            "Rdc": "1.09804",
             "Runits": "mi",
-            "diam": "0.3980000",
-            "emergamps": "-1",
+            "diam": "0.398",
+            "emergamps": "345",
             "like": "",
-            "normamps": "230.0000",
-            "radius": "-1",
+            "normamps": "230",
+            "radius": "0.199",
             "radunits": "in",
         },
         "wiredata.acsr336": {
-            "Capradius": "-1",
+            "Capradius": "0.3705",
             "Seasons": "1",
             "Ratings": ["-1"],
-            "GMRac": "0.0255000",
+            "GMRac": "0.0255",
             "GMRunits": "ft",
-            "Rac": "0.3060000",
-            "Rdc": "-1",
+            "Rac": "0.306",
+            "Rdc": "0.3",
             "Runits": "mi",
-            "diam": "0.7410000",
-            "emergamps": "-1",
+            "diam": "0.741",
+            "emergamps": "795",
             "like": "",
-            "normamps": "530.0000",
-            "radius": "-1",
+            "normamps": "530",
+            "radius": "0.3705",
             "radunits": "in",
         },
     }


### PR DESCRIPTION
Upgrade to DSS Python 0.10.7:

- Expose 4 new functions ported from the upstream OpenDSS
- Update tests. Changes related to number of commands, the new functions, and updated property values -- [changes to WireData formatting](https://github.com/dss-extensions/dss_capi/commit/ce502eb262414860a39b9bb264a4dda8f210b488#diff-b90d5769144689c2b00362be84ab941a6bf31df2e6127c6991f6c52d49845b6aR354-R399) required updates to the tests.
- Drop Python 2.7, add Python 3.9 -- due to this, updated version to 0.6.0
- Pin dss_python==0.10.7

DSS Python 0.10.7 changes:

- Maintenance release. 
- Updated to DSS C-API 0.10.7, which includes most changes up to OpenDSS v9.1.3.4.
- Includes an important bug fix related to the `CapRadius` DSS property. If your DSS scripts included the pattern `GMRac=... rad=...` or `GMRac=... diam=...` (in this order and without specifying `CapRadius`), you should upgrade and re-evaluate the results. 
- New API properties ported from the official COM interface: `Bus.AllPCEatBus`, `Bus.AllPDEatBus`, `CktElement.TotalPowers`, `Meters.ZonePCE`

DSS C-API 0.10.7 changes:

- Simple maintenance release, which includes most changes up to OpenDSS v9.1.3.4 (revision 2963).
- Includes an important bug fix related to the `CapRadius` DSS property. If your DSS scripts included the pattern `GMRac=... rad=...` or `GMRac=... diam=...` (in this order and without specifying `CapRadius`), you should upgrade and re-evaluate the results. 
- This version should be fully API compatible with 0.10.3+.
- A reference document listing the DSS commands and properties for all DSS elements is now available at https://github.com/dss-extensions/dss_capi/blob/0.10.x/docs/dss_properties.md
- New functions API ported from the official OpenDSS include: `Bus_Get_AllPCEatBus`, `Bus_Get_AllPDEatBus`, `CktElement_Get_TotalPowers`, `Meters_Get_ZonePCE`.
- The changes ported from the official OpenDSS include the following (check the repository for more details):
    - "Adds LineType property to LineCode and LineGeometry objects."
    - "Correcting bug found in storage device when operating in idling mode. It was preventing the solution of other test feeders (IEEE 9500)"
    - "Enabling fuel option for generator, fixing bug found in TotalPower command."
    - "Adding kvar compensation calculation for normalizing reactive power at feeder head. v 9.1.2.4"
    - "Adding: - Line type variable to line definition. - AllPCEatBus and AllPDEatBus commands to the executive command set. - AllPCEatBus and AllPDEatBus commands to bus interface in COM/DLL. (...)"
    - "Adding capability to energy meter for getting the list of all PCE (shunt) within a zone. Interface "AllPCEatZone" for COM/DLL created."
    - "Fixing bug found when calculating voltage bases with large amount of numbers (large array)."
