### PR TITLE
Implement utils.monitor_to_dataframe

### DIFF
--- a/opendssdirect/Monitors.py
+++ b/opendssdirect/Monitors.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 import numpy as np
 from ._utils import (
+    api_util,
     lib,
     codec,
     CheckForError,
@@ -201,7 +202,7 @@ def AsMatrix():
     Matrix of the active monitor, containing the hour vector, seconds vector, and all channels (index 2 = channel 1).
     If you need multiple channels, prefer using this function as it processes the monitor byte-stream once.
     """
-    buffer = get_int8_array(lib.Monitors_Get_ByteStream)
+    buffer = api_util.get_int8_array(lib.Monitors_Get_ByteStream)
     CheckForError()
     if len(buffer) <= 1:
         return None

--- a/tests/test_opendssdirect.py
+++ b/tests/test_opendssdirect.py
@@ -1963,6 +1963,56 @@ def test_13Node_Monitors(dss):
     assert dss.Monitors.ResetAll() is None
     assert dss.Monitors.SaveAll() is None
     assert dss.Monitors.SampleAll() is None
+    
+    dss.Text.Command("new monitor.test_monitor element=Transformer.Reg3 terminal=2 mode=2")
+    dss.Text.Command("solve mode=daily step=15m number=10")
+    
+    assert dss.Monitors.Count() == 1
+    assert dss.Monitors.First() == 1
+    
+    expected_dict = pd.DataFrame(
+        {
+            "Tap (pu)": {
+                0: 1.056249976158142,
+                1: 1.056249976158142,
+                2: 1.056249976158142,
+                3: 1.056249976158142,
+                4: 1.056249976158142,
+                5: 1.056249976158142,
+                6: 1.056249976158142,
+                7: 1.056249976158142,
+                8: 1.056249976158142,
+                9: 1.056249976158142
+            },
+            "hour": {
+                0: 0.0,
+                1: 0.0,
+                2: 0.0,
+                3: 1.0,
+                4: 1.0,
+                5: 1.0,
+                6: 1.0,
+                7: 2.0,
+                8: 2.0,
+                9: 2.0
+            },
+            "second": {
+                0: 900.0,
+                1: 1800.0,
+                2: 2700.0,
+                3: 0.0,
+                4: 900.0,
+                5: 1800.0,
+                6: 2700.0,
+                7: 0.0,
+                8: 900.0,
+                9: 1800.0
+            }
+        }
+    ).to_dict()
+
+    actual_dict = dss.utils.monitor_to_dataframe().to_dict()
+    assert_dict_equal(actual_dict, expected_dict)
 
 
 def test_13Node_PDElements(dss):


### PR DESCRIPTION
Small changes to properly add `monitor_to_dataframe`, closes #12.