### PR TITLE
DSS Python 0.10.7-1

### DIFF
--- a/opendssdirect/_version.py
+++ b/opendssdirect/_version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     author_email="me@kdheepak.com",
     license="BSD-compatible",
     packages=find_packages(),
-    install_requires=["future", "six", "dss_python==0.10.7"],
+    install_requires=["future", "six", "dss_python==0.10.7.post1"],
     extras_require={
         "extras": ["pandas", "matplotlib", "networkx"],
         "dev": [


### PR DESCRIPTION
Just a minor fix, affecting only the energy meter (text) reports. No other changes.

Since we're pinning exact versions, even a `-1` (post1) release requires a new release. I think that's the best for now.