### PR TITLE
Use environment variable for numpy version

### DIFF
--- a/opendssdirect/_utils.py
+++ b/opendssdirect/_utils.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import dss as dss_py
 import numpy as np
 import warnings
+import os
 
 # Bind to the FFI module instance. This should be refined in a future version,
 # especially after DSS C-API 0.11 is fully released.
@@ -18,12 +19,22 @@ DSSException = dss_py._cffi_api_util.DSSException
 
 # Currently, we prefer the functions that return lists (suffix 2)
 # to keep higher compatibility with previous versions of OpenDSSDirect.py.
-
-get_string = api_util.get_string
-get_float64_array = api_util.get_float64_array2
-get_int32_array = api_util.get_int32_array2
-get_int8_array = api_util.get_int8_array2
-get_string_array = api_util.get_string_array2
+if os.environ.get("OPENDSSDIRECT_PY_USE_NUMPY"):
+    get_string = api_util.get_string
+    get_float64_array = api_util.get_float64_array
+    get_int32_array = api_util.get_int32_array
+    get_int8_array = api_util.get_int8_array
+    # TODO: Fix the following once https://github.com/dss-extensions/dss_python/pull/35 is merged
+    # get_string_array = api_util.get_string_array
+    def get_string_array(*args, **kwargs):
+        l = api_util.get_string_array(*args, **kwargs)
+        return [i for i in l if i != "" and i != "NONE"]
+else:
+    get_string = api_util.get_string
+    get_float64_array = api_util.get_float64_array2
+    get_int32_array = api_util.get_int32_array2
+    get_int8_array = api_util.get_int8_array2
+    get_string_array = api_util.get_string_array2
 prepare_float64_array = api_util.prepare_float64_array
 prepare_int32_array = api_util.prepare_int32_array
 prepare_string_array = api_util.prepare_string_array

--- a/tests/test_opendssdirect.py
+++ b/tests/test_opendssdirect.py
@@ -330,12 +330,12 @@ def test_13Node_Bus(dss):
     assert dss.Bus.Cust_Interrupts() == 0.0
     assert dss.Bus.Distance() == 0.0
     assert dss.Bus.Int_Duration() == 0.0
-    assert dss.Bus.Isc() == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Bus.Isc(), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     assert dss.Bus.Lambda() == 0.0
     assert dss.Bus.N_Customers() == 0
     assert dss.Bus.N_interrupts() == 0.0
     assert dss.Bus.Name() == u"sourcebus"
-    assert dss.Bus.Nodes() == [1, 2, 3]
+    np.testing.assert_array_equal(dss.Bus.Nodes(), [1, 2, 3])
     assert dss.Bus.NumNodes() == 3
     np.testing.assert_array_almost_equal(
         dss.Bus.PuVoltage(),
@@ -380,7 +380,7 @@ def test_13Node_Bus(dss):
         ],
         decimal=4,
     )
-    assert dss.Bus.Voc() == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Bus.Voc(), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     np.testing.assert_array_almost_equal(
         dss.Bus.Voltages(),
         [
@@ -395,10 +395,10 @@ def test_13Node_Bus(dss):
     )
     assert dss.Bus.X() == 200.0
     assert dss.Bus.Y() == 400.0
-    assert dss.Bus.YscMatrix() == [0.0]
-    assert dss.Bus.Zsc0() == [0.0, 0.0]
-    assert dss.Bus.Zsc1() == [0.0, 0.0]
-    assert dss.Bus.ZscMatrix() == [0.0]
+    np.testing.assert_array_almost_equal(dss.Bus.YscMatrix(), [0.0])
+    np.testing.assert_array_almost_equal(dss.Bus.Zsc0(), [0.0, 0.0])
+    np.testing.assert_array_almost_equal(dss.Bus.Zsc1(), [0.0, 0.0])
+    np.testing.assert_array_almost_equal(dss.Bus.ZscMatrix(), [0.0])
     assert dss.Bus.ZscRefresh() == 1
     assert dss.Bus.kVBase() == 66.39528095680697
     np.testing.assert_array_almost_equal(
@@ -430,13 +430,13 @@ def test_13Node_Bus(dss):
 
     # TODO: this should not be sorted, we should define the order of the results
     assert sorted(dss.YMatrix.getV()[2:]) == sorted(dss.Circuit.AllBusVolts())
-    
-    assert dss.Bus.AllPDEatBus() == ["Transformer.sub"]
-    assert dss.Bus.AllPCEatBus() == ["Vsource.source"]
-    
+
+    np.testing.assert_array_equal(dss.Bus.AllPDEatBus(), ["Transformer.sub"])
+    np.testing.assert_array_equal(dss.Bus.AllPCEatBus(), ["Vsource.source"])
+
     dss.Circuit.SetActiveBus("684")
-    assert dss.Bus.AllPDEatBus() == ['Line.671684', 'Line.684611', 'Line.684652']
-    assert dss.Bus.AllPCEatBus() == []
+    np.testing.assert_array_equal(dss.Bus.AllPDEatBus(), ['Line.671684', 'Line.684611', 'Line.684652'])
+    np.testing.assert_array_equal(dss.Bus.AllPCEatBus(), [])
 
 
 def test_13Node_Circuit(dss):
@@ -785,7 +785,7 @@ def test_13Node_Circuit(dss):
         u"Line.684652",
         u"Line.671692",
     ]
-    assert dss.Circuit.AllNodeDistances() == [
+    np.testing.assert_array_almost_equal(dss.Circuit.AllNodeDistances(), [
         0.0,
         0.0,
         0.0,
@@ -827,8 +827,8 @@ def test_13Node_Circuit(dss):
         0.0,
         0.0,
         0.0,
-    ]
-    assert dss.Circuit.AllNodeNames() == [
+    ])
+    np.testing.assert_array_equal(dss.Circuit.AllNodeNames(), [
         u"sourcebus.1",
         u"sourcebus.2",
         u"sourcebus.3",
@@ -870,7 +870,7 @@ def test_13Node_Circuit(dss):
         u"680.3",
         u"684.1",
         u"684.3",
-    ]
+    ])
     #    assert dss.Circuit.Capacity() == 0.0 ---- NEEDS PARAMS
     assert dss.Circuit.Disable("632") is None
     assert dss.Circuit.Enable("632") is None
@@ -908,7 +908,7 @@ def test_13Node_Circuit(dss):
     assert dss.Circuit.SetActiveClass("Load") == 20
 
     assert dss.Circuit.SetActiveElement("") == -1
-    assert dss.Circuit.SubstationLosses() == [0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Circuit.SubstationLosses(), [0.0, 0.0])
     np.testing.assert_array_almost_equal(
         dss.Circuit.TotalPower(), [-3567.2130572232213, -1736.5876246039768], decimal=4
     )
@@ -1001,7 +1001,7 @@ def test_13Node_Circuit(dss):
         ],
         decimal=4,
     )
-    assert dss.Circuit.YNodeOrder() == [
+    np.testing.assert_array_equal(dss.Circuit.YNodeOrder(), [
         u"SOURCEBUS.1",
         u"SOURCEBUS.2",
         u"SOURCEBUS.3",
@@ -1043,7 +1043,7 @@ def test_13Node_Circuit(dss):
         u"692.2",
         u"684.1",
         u"684.3",
-    ]
+    ])
     np.testing.assert_array_almost_equal(
         dss.Circuit.YNodeVArray(),
         [
@@ -1176,9 +1176,9 @@ def test_13Node_CktElement(dss):
         u"enabled",
         u"like",
     ]
-    assert dss.CktElement.AllVariableNames() == []
-    assert dss.CktElement.AllVariableValues() == [0.0]
-    assert dss.CktElement.BusNames() == [u"671", u"692"]
+    np.testing.assert_array_equal(dss.CktElement.AllVariableNames(), [])
+    np.testing.assert_array_almost_equal(dss.CktElement.AllVariableValues(), [0.0])
+    np.testing.assert_array_equal(dss.CktElement.BusNames(), [u"671", u"692"])
     assert dss.CktElement.Open(1, 0) is None
     assert dss.CktElement.IsOpen(1, 0)
     assert dss.CktElement.Close(1, 0) is None
@@ -1270,7 +1270,7 @@ def test_13Node_CktElement(dss):
         decimal=4,
     )
     assert dss.CktElement.Name() == u"Line.671692"
-    assert dss.CktElement.NodeOrder() == [1, 2, 3, 1, 2, 3]
+    np.testing.assert_array_equal(dss.CktElement.NodeOrder(), [1, 2, 3, 1, 2, 3])
     np.testing.assert_almost_equal(
         dss.CktElement.TotalPowers(),
         [1013.9070515856262, 19.023976609590814, -1013.9070425310053, -19.023976609590783],
@@ -1493,7 +1493,7 @@ def test_13Node_CktElement(dss):
     # Create an element with "variables" available to test
     dss.run_command("New PVSystem.631")
     dss.Circuit.SetActiveElement("PVSystem.631")
-    assert dss.CktElement.AllVariableNames() == [
+    np.testing.assert_array_equal(dss.CktElement.AllVariableNames(), [
         u"Irradiance",
         u"PanelkW",
         u"P_TFactor",
@@ -1507,8 +1507,8 @@ def test_13Node_CktElement(dss):
         u"watt-pf",
         u"watt-var",
         u"kW_out_desired",
-    ]
-    assert dss.CktElement.AllVariableValues() == [
+    ])
+    np.testing.assert_array_almost_equal(dss.CktElement.AllVariableValues(), [
         1.0,
         500.0,
         1.0,
@@ -1522,7 +1522,7 @@ def test_13Node_CktElement(dss):
         9999.0,
         9999.0,
         500.0,
-    ]
+    ])
     assert dss.CktElement.Variablei(2) == 500.0
     assert dss.CktElement.Variable(u"PanelkW") == 500.0
 
@@ -1692,7 +1692,7 @@ def test_13Node_Isource(dss):
 
 def test_13Node_Lines(dss):
 
-    assert dss.Lines.AllNames() == [
+    np.testing.assert_array_equal(dss.Lines.AllNames(), [
         u"650632",
         u"632670",
         u"670671",
@@ -1705,12 +1705,12 @@ def test_13Node_Lines(dss):
         u"684611",
         u"684652",
         u"671692",
-    ]
+    ])
     assert dss.Lines.Bus1() == u"671"
     assert dss.Lines.Bus2() == u"692"
     assert dss.Lines.C0() == 0.0
     assert dss.Lines.C1() == 0.0
-    assert dss.Lines.CMatrix() == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Lines.CMatrix(), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     assert dss.Lines.Count() == 12
     assert dss.Lines.EmergAmps() == 600.0
     assert dss.Lines.First() == 1
@@ -1728,7 +1728,7 @@ def test_13Node_Lines(dss):
     assert dss.Lines.Spacing() == u""
     assert dss.Lines.Units() == 5
     assert dss.Lines.Xg() == 0.155081
-    assert dss.Lines.Yprim() == [
+    np.testing.assert_array_almost_equal(dss.Lines.Yprim(), [
         3.4335554553543783,
         -9.8965831153747,
         -1.4568043853617796,
@@ -1801,7 +1801,7 @@ def test_13Node_Lines(dss):
         2.0889991803940724,
         2.658753201413196,
         -8.847115639537611,
-    ]
+    ])
     with pt.raises(dss.DSSException):
         # This is not allowed at the moment (the value is/was ignored before)
         # so an exception was added in case someone was trying to use it
@@ -1809,7 +1809,7 @@ def test_13Node_Lines(dss):
 
     assert dss.Lines.R0() == 3.378880258497484e-05
     assert dss.Lines.X0() == 7.664982290436836e-05
-    assert dss.Lines.RMatrix() == [
+    np.testing.assert_array_almost_equal(dss.Lines.RMatrix(), [
         6.562679425837321e-05,
         2.9546262350090106e-05,
         2.992506058534767e-05,
@@ -1819,8 +1819,8 @@ def test_13Node_Lines(dss):
         2.992506058534767e-05,
         2.9072764556018148e-05,
         6.466085875846642e-05,
-    ]
-    assert dss.Lines.XMatrix() == [
+    ])
+    np.testing.assert_array_almost_equal(dss.Lines.XMatrix(), [
         0.00019278936183433795,
         9.502153731436029e-05,
         8.022946622755235e-05,
@@ -1830,7 +1830,7 @@ def test_13Node_Lines(dss):
         8.022946622755235e-05,
         7.289972037531847e-05,
         0.00019599020692226434,
-    ]
+    ])
 
     assert dss.Lines.R1() == 1.0985148822469399e-05
     assert dss.Lines.X1() == 2.2841533586031195e-05
@@ -1838,7 +1838,7 @@ def test_13Node_Lines(dss):
 
 def test_13Node_Loads(dss):
 
-    assert dss.Loads.AllNames() == [
+    np.testing.assert_array_equal(dss.Loads.AllNames(), [
         u"671",
         u"634a",
         u"634b",
@@ -1854,7 +1854,7 @@ def test_13Node_Loads(dss):
         u"670a",
         u"670b",
         u"670c",
-    ]
+    ])
     assert dss.Loads.AllocationFactor() == 0.5
     assert dss.Loads.CFactor() == 4.0
     assert dss.Loads.CVRCurve() == u""
@@ -1886,7 +1886,7 @@ def test_13Node_Loads(dss):
     assert dss.Loads.XfkVA() == 0.0
     assert dss.Loads.Xneut() == 0.0
     assert dss.Loads.Yearly() == u""
-    assert dss.Loads.ZipV() == []
+    np.testing.assert_array_almost_equal(dss.Loads.ZipV(), [])
     assert dss.Loads.kV() == 0.277
     assert dss.Loads.kVABase() == 194.164878389476
     assert dss.Loads.kW() == 160.0
@@ -1897,17 +1897,17 @@ def test_13Node_Loads(dss):
 
 
 def test_13Node_LoadShape(dss):
-    assert dss.LoadShape.AllNames() == [u"default"]
+    np.testing.assert_array_equal(dss.LoadShape.AllNames(), [u"default"])
     assert dss.LoadShape.Count() == 1
     assert dss.LoadShape.First() == 1
     assert dss.LoadShape.HrInterval() == 1.0
     assert dss.LoadShape.MinInterval() == 60.0
-    assert dss.LoadShape.Name() == u"default"
+    np.testing.assert_array_equal(dss.LoadShape.Name(), u"default")
     assert dss.LoadShape.Next() == 0
     assert dss.LoadShape.Normalize() is None
     assert dss.LoadShape.Npts() == 24
     assert dss.LoadShape.PBase() == 0.0
-    assert dss.LoadShape.PMult() == [
+    np.testing.assert_array_almost_equal(dss.LoadShape.PMult(), [
         0.677,
         0.6256,
         0.6087,
@@ -1932,11 +1932,11 @@ def test_13Node_LoadShape(dss):
         0.876,
         0.828,
         0.756,
-    ]
+    ])
     assert dss.LoadShape.QBase() == 0.0
-    assert dss.LoadShape.QMult() == [0.0]
+    np.testing.assert_array_almost_equal(dss.LoadShape.QMult(), [0.0])
     assert dss.LoadShape.SInterval() == 3600.0
-    assert dss.LoadShape.TimeArray() == [0.0]
+    np.testing.assert_array_almost_equal(dss.LoadShape.TimeArray(), [0.0])
     assert dss.LoadShape.UseActual() == 0
 
 
@@ -1963,13 +1963,13 @@ def test_13Node_Monitors(dss):
     assert dss.Monitors.ResetAll() is None
     assert dss.Monitors.SaveAll() is None
     assert dss.Monitors.SampleAll() is None
-    
+
     dss.Text.Command("new monitor.test_monitor element=Transformer.Reg3 terminal=2 mode=2")
     dss.Text.Command("solve mode=daily step=15m number=10")
-    
+
     assert dss.Monitors.Count() == 1
     assert dss.Monitors.First() == 1
-    
+
     expected_dict = pd.DataFrame(
         {
             "Tap (pu)": {
@@ -2077,12 +2077,12 @@ def test_13Node_PDElements(dss):
     for name in all_names:
         # We have to iterate by name to include disabled elements
         dss.PDElements.Name(name)
-        
+
         currents = np.asarray(dss.CktElement.Currents()).view(dtype=complex)
-        
+
         all_max_currents2.append(np.max(np.abs(currents[:dss.CktElement.NumPhases()])))
         all_max_currents_all_terms_2.append(np.max(np.abs(currents)))
-        
+
         all_currents2.append(currents)
         all_norm_amp2.append(dss.CktElement.NormalAmps())
         all_emerg_amp2.append(dss.CktElement.EmergAmps())
@@ -2096,8 +2096,8 @@ def test_13Node_PDElements(dss):
 
     np.testing.assert_array_almost_equal(all_max_currents, all_max_currents2, decimal=4)
     np.testing.assert_array_almost_equal(
-        all_max_currents_all_terms, 
-        all_max_currents_all_terms_2, 
+        all_max_currents_all_terms,
+        all_max_currents_all_terms_2,
         decimal=4
     )
 
@@ -2114,8 +2114,8 @@ def test_13Node_PDElements(dss):
     )
 
     np.testing.assert_array_almost_equal(
-        np.asarray(all_currents).view(dtype=complex), 
-        np.concatenate(all_currents2), 
+        np.asarray(all_currents).view(dtype=complex),
+        np.concatenate(all_currents2),
         decimal=4
     )
 
@@ -2228,7 +2228,7 @@ def test_13Node_Settings(dss):
     assert dss.Settings.Trapezoidal() == 0
     assert dss.Settings.UERegs() == [10]
     assert dss.Settings.UEWeight() == 1.0
-    assert dss.Settings.VoltageBases() == [115.0, 4.16, 0.48]
+    np.testing.assert_array_almost_equal(dss.Settings.VoltageBases(), [115.0, 4.16, 0.48])
     assert dss.Settings.ZoneLock() == 0
 
 

--- a/tests/test_opendssdirect_no_ext_errors.py
+++ b/tests/test_opendssdirect_no_ext_errors.py
@@ -175,7 +175,7 @@ def test_module_import():
 def test_ActiveClass(dss):
 
     assert dss.ActiveClass.ActiveClassName() == u"Line"
-    assert dss.ActiveClass.AllNames() == [
+    np.testing.assert_array_equal(dss.ActiveClass.AllNames(), [
         u"650632",
         u"632670",
         u"670671",
@@ -188,7 +188,7 @@ def test_ActiveClass(dss):
         u"684611",
         u"684652",
         u"671692",
-    ]
+    ])
     assert dss.ActiveClass.Count() == 12
     assert dss.ActiveClass.First() == 1
     assert dss.ActiveClass.Name() == u"650632"
@@ -219,7 +219,7 @@ def test_configuration():
 def test_13Node(dss):
 
     assert dss.ActiveClass.ActiveClassName() == u"Line"
-    assert dss.ActiveClass.AllNames() == [
+    np.testing.assert_array_equal(dss.ActiveClass.AllNames(), [
         u"650632",
         u"632670",
         u"670671",
@@ -232,7 +232,7 @@ def test_13Node(dss):
         u"684611",
         u"684652",
         u"671692",
-    ]
+    ])
     assert dss.ActiveClass.Count() == 12
     assert dss.ActiveClass.First() == 1
     assert dss.ActiveClass.Name() == u"650632"
@@ -305,7 +305,7 @@ def test_13Node_Basic(dss):
     assert dss.Basic.NumUserClasses() == 0
     assert dss.Basic.Reset() is None
     assert dss.Basic.Start(1) == 1
-    assert dss.Basic.UserClasses() == []
+    np.testing.assert_array_almost_equal(dss.Basic.UserClasses(), [])
     from six import string_types
 
     # u'Version xxxx (64-bit build); License Status: Open '
@@ -331,12 +331,12 @@ def test_13Node_Bus(dss):
     assert dss.Bus.Cust_Interrupts() == 0.0
     assert dss.Bus.Distance() == 0.0
     assert dss.Bus.Int_Duration() == 0.0
-    assert dss.Bus.Isc() == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Bus.Isc(), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     assert dss.Bus.Lambda() == 0.0
     assert dss.Bus.N_Customers() == 0
     assert dss.Bus.N_interrupts() == 0.0
     assert dss.Bus.Name() == u"sourcebus"
-    assert dss.Bus.Nodes() == [1, 2, 3]
+    np.testing.assert_array_equal(dss.Bus.Nodes(), [1, 2, 3])
     assert dss.Bus.NumNodes() == 3
     np.testing.assert_array_almost_equal(
         dss.Bus.PuVoltage(),
@@ -381,7 +381,7 @@ def test_13Node_Bus(dss):
         ],
         decimal=4,
     )
-    assert dss.Bus.Voc() == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Bus.Voc(), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     np.testing.assert_array_almost_equal(
         dss.Bus.Voltages(),
         [
@@ -396,10 +396,10 @@ def test_13Node_Bus(dss):
     )
     assert dss.Bus.X() == 200.0
     assert dss.Bus.Y() == 400.0
-    assert dss.Bus.YscMatrix() == [0.0]
-    assert dss.Bus.Zsc0() == [0.0, 0.0]
-    assert dss.Bus.Zsc1() == [0.0, 0.0]
-    assert dss.Bus.ZscMatrix() == [0.0]
+    np.testing.assert_array_almost_equal(dss.Bus.YscMatrix(), [0.0])
+    np.testing.assert_array_almost_equal(dss.Bus.Zsc0(), [0.0, 0.0])
+    np.testing.assert_array_almost_equal(dss.Bus.Zsc1(), [0.0, 0.0])
+    np.testing.assert_array_almost_equal(dss.Bus.ZscMatrix(), [0.0])
     assert dss.Bus.ZscRefresh() == 1
     assert dss.Bus.kVBase() == 66.39528095680697
     np.testing.assert_array_almost_equal(
@@ -504,7 +504,7 @@ def test_13Node_Circuit(dss):
         ],
         decimal=4,
     )
-    assert dss.Circuit.AllBusNames() == [
+    np.testing.assert_array_equal(dss.Circuit.AllBusNames(), [
         u"sourcebus",
         u"650",
         u"rg60",
@@ -521,7 +521,7 @@ def test_13Node_Circuit(dss):
         u"632",
         u"680",
         u"684",
-    ]
+    ])
     np.testing.assert_array_almost_equal(
         dss.Circuit.AllBusVMag(),
         [
@@ -739,7 +739,7 @@ def test_13Node_Circuit(dss):
         ],
         decimal=4,
     )
-    assert dss.Circuit.AllElementNames() == [
+    np.testing.assert_array_equal(dss.Circuit.AllElementNames(), [
         u"Vsource.source",
         u"Transformer.sub",
         u"Transformer.reg1",
@@ -778,8 +778,8 @@ def test_13Node_Circuit(dss):
         u"Line.684611",
         u"Line.684652",
         u"Line.671692",
-    ]
-    assert dss.Circuit.AllNodeDistances() == [
+    ])
+    np.testing.assert_array_almost_equal(dss.Circuit.AllNodeDistances(), [
         0.0,
         0.0,
         0.0,
@@ -821,8 +821,8 @@ def test_13Node_Circuit(dss):
         0.0,
         0.0,
         0.0,
-    ]
-    assert dss.Circuit.AllNodeNames() == [
+    ])
+    np.testing.assert_array_equal(dss.Circuit.AllNodeNames(), [
         u"sourcebus.1",
         u"sourcebus.2",
         u"sourcebus.3",
@@ -864,7 +864,7 @@ def test_13Node_Circuit(dss):
         u"680.3",
         u"684.1",
         u"684.3",
-    ]
+    ])
     #    assert dss.Circuit.Capacity() == 0.0 ---- NEEDS PARAMS
     assert dss.Circuit.Disable("632") is None
     assert dss.Circuit.Enable("632") is None
@@ -902,7 +902,7 @@ def test_13Node_Circuit(dss):
     assert dss.Circuit.SetActiveClass("Load") == 20
 
     assert dss.Circuit.SetActiveElement("") == -1
-    assert dss.Circuit.SubstationLosses() == [0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Circuit.SubstationLosses(), [0.0, 0.0])
     np.testing.assert_array_almost_equal(
         dss.Circuit.TotalPower(), [-3567.2130572232213, -1736.5876246039768], decimal=4
     )
@@ -995,7 +995,7 @@ def test_13Node_Circuit(dss):
         ],
         decimal=4,
     )
-    assert dss.Circuit.YNodeOrder() == [
+    np.testing.assert_array_equal(dss.Circuit.YNodeOrder(), [
         u"SOURCEBUS.1",
         u"SOURCEBUS.2",
         u"SOURCEBUS.3",
@@ -1037,7 +1037,7 @@ def test_13Node_Circuit(dss):
         u"692.2",
         u"684.1",
         u"684.3",
-    ]
+    ])
     np.testing.assert_array_almost_equal(
         dss.Circuit.YNodeVArray(),
         [
@@ -1130,7 +1130,7 @@ def test_13Node_Circuit(dss):
 
 def test_13Node_CktElement(dss):
 
-    assert dss.CktElement.AllPropertyNames() == [
+    np.testing.assert_array_equal(dss.CktElement.AllPropertyNames(), [
         u"bus1",
         u"bus2",
         u"linecode",
@@ -1169,10 +1169,10 @@ def test_13Node_CktElement(dss):
         u"basefreq",
         u"enabled",
         u"like",
-    ]
-    assert dss.CktElement.AllVariableNames() == []
-    assert dss.CktElement.AllVariableValues() == [0.0]
-    assert dss.CktElement.BusNames() == [u"671", u"692"]
+    ])
+    np.testing.assert_array_equal(dss.CktElement.AllVariableNames(), [])
+    np.testing.assert_array_almost_equal(dss.CktElement.AllVariableValues(), [0.0])
+    np.testing.assert_array_equal(dss.CktElement.BusNames(), [u"671", u"692"])
     assert dss.CktElement.Open(1, 0) is None
     assert dss.CktElement.IsOpen(1, 0)
     assert dss.CktElement.Close(1, 0) is None
@@ -1264,7 +1264,7 @@ def test_13Node_CktElement(dss):
         decimal=4,
     )
     assert dss.CktElement.Name() == u"Line.671692"
-    assert dss.CktElement.NodeOrder() == [1, 2, 3, 1, 2, 3]
+    np.testing.assert_array_equal(dss.CktElement.NodeOrder(), [1, 2, 3, 1, 2, 3])
     assert dss.CktElement.NormalAmps() == 400.0
     assert dss.CktElement.NumConductors() == 3
     assert dss.CktElement.NumControls() == 0
@@ -1482,7 +1482,7 @@ def test_13Node_CktElement(dss):
     # Create an element with "variables" available to test
     dss.run_command("New PVSystem.631")
     dss.Circuit.SetActiveElement("PVSystem.631")
-    assert dss.CktElement.AllVariableNames() == [
+    np.testing.assert_array_equal(dss.CktElement.AllVariableNames(), [
         u"Irradiance",
         u"PanelkW",
         u"P_TFactor",
@@ -1496,8 +1496,8 @@ def test_13Node_CktElement(dss):
         u"watt-pf",
         u"watt-var",
         u"kW_out_desired",
-    ]
-    assert dss.CktElement.AllVariableValues() == [
+    ])
+    np.testing.assert_array_almost_equal(dss.CktElement.AllVariableValues(), [
         1.0,
         500.0,
         1.0,
@@ -1511,14 +1511,14 @@ def test_13Node_CktElement(dss):
         9999.0,
         9999.0,
         500.0,
-    ]
+    ])
     assert dss.CktElement.Variablei(2) == 500.0
     assert dss.CktElement.Variable(u"PanelkW") == 500.0
 
 
 def test_13Node_Capacitors(dss):
     assert dss.Capacitors.AddStep() == 0
-    assert dss.Capacitors.AllNames() == [u"cap1", u"cap2"]
+    np.testing.assert_array_equal(dss.Capacitors.AllNames(), [u"cap1", u"cap2"])
     assert dss.Capacitors.AvailableSteps() == 0
     assert dss.Capacitors.Close() is None
     assert dss.Capacitors.Count() == 2
@@ -1528,14 +1528,14 @@ def test_13Node_Capacitors(dss):
     assert dss.Capacitors.Next() == 2
     assert dss.Capacitors.NumSteps() == 1
     assert dss.Capacitors.Open() is None
-    assert dss.Capacitors.States() == [0]
+    np.testing.assert_array_almost_equal(dss.Capacitors.States(), [0])
     assert dss.Capacitors.SubtractStep() == 0
     assert dss.Capacitors.kV() == 2.4
     assert dss.Capacitors.kvar() == 100.0
 
 
 def test_13Node_CapControls(dss):
-    assert dss.CapControls.AllNames() == []
+    np.testing.assert_array_equal(dss.CapControls.AllNames(), [])
     assert dss.CapControls.CTRatio() == 0.0
     assert dss.CapControls.Capacitor() == u""
     assert dss.CapControls.Count() == 0
@@ -1556,7 +1556,7 @@ def test_13Node_CapControls(dss):
 
 
 def test_13Node_Element(dss):
-    assert dss.Element.AllPropertyNames() == [
+    np.testing.assert_array_equal(dss.Element.AllPropertyNames(), [
         u"bus1",
         u"bus2",
         u"linecode",
@@ -1595,7 +1595,7 @@ def test_13Node_Element(dss):
         u"basefreq",
         u"enabled",
         u"like",
-    ]
+    ])
     assert dss.Element.Name() == u"Line.671692"
     assert dss.Element.NumProperties() == 38
 
@@ -1621,7 +1621,7 @@ def test_13Node_Executive(dss):
 
 
 def test_13Node_Fuses(dss):
-    assert dss.Fuses.AllNames() == []
+    np.testing.assert_array_equal(dss.Fuses.AllNames(), [])
     assert dss.Fuses.Close() is None
     assert dss.Fuses.Count() == 0
     assert dss.Fuses.First() == 0
@@ -1640,7 +1640,7 @@ def test_13Node_Fuses(dss):
 
 def test_13Node_Generators(dss):
 
-    assert dss.Generators.AllNames() == []
+    np.testing.assert_array_equal(dss.Generators.AllNames(), [])
     assert dss.Generators.Count() == 0
     assert dss.Generators.First() == 0
     assert dss.Generators.ForcedON() == 0
@@ -1650,15 +1650,15 @@ def test_13Node_Generators(dss):
     assert dss.Generators.Next() == 0
     assert dss.Generators.PF() == 0.0
     assert dss.Generators.Phases() == 0
-    assert dss.Generators.RegisterNames() == [
+    np.testing.assert_array_equal(dss.Generators.RegisterNames(), [
         u"kWh",
         u"kvarh",
         u"Max kW",
         u"Max kVA",
         u"Hours",
         u"$",
-    ]
-    assert dss.Generators.RegisterValues() == [0.0]
+    ])
+    np.testing.assert_array_almost_equal(dss.Generators.RegisterValues(), [0.0])
     assert dss.Generators.Vmaxpu() == -1.0
     assert dss.Generators.Vminpu() == -1.0
     assert dss.Generators.kV() == -1.0
@@ -1669,7 +1669,7 @@ def test_13Node_Generators(dss):
 
 def test_13Node_Isource(dss):
 
-    assert dss.Isource.AllNames() == []
+    np.testing.assert_array_equal(dss.Isource.AllNames(), [])
     assert dss.Isource.Amps() == 0.0
     assert dss.Isource.AngleDeg() == 0.0
     assert dss.Isource.Count() == 0
@@ -1686,7 +1686,7 @@ def test_13Node_Isource(dss):
 
 def test_13Node_Lines(dss):
 
-    assert dss.Lines.AllNames() == [
+    np.testing.assert_array_equal(dss.Lines.AllNames(), [
         u"650632",
         u"632670",
         u"670671",
@@ -1699,12 +1699,12 @@ def test_13Node_Lines(dss):
         u"684611",
         u"684652",
         u"671692",
-    ]
+    ])
     assert dss.Lines.Bus1() == u"671"
     assert dss.Lines.Bus2() == u"692"
     assert dss.Lines.C0() == 0.0
     assert dss.Lines.C1() == 0.0
-    assert dss.Lines.CMatrix() == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    np.testing.assert_array_almost_equal(dss.Lines.CMatrix(), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     assert dss.Lines.Count() == 12
     assert dss.Lines.EmergAmps() == 600.0
     assert dss.Lines.First() == 1
@@ -1722,7 +1722,7 @@ def test_13Node_Lines(dss):
     assert dss.Lines.Spacing() == u""
     assert dss.Lines.Units() == 5
     assert dss.Lines.Xg() == 0.155081
-    assert dss.Lines.Yprim() == [
+    np.testing.assert_array_almost_equal(dss.Lines.Yprim(), [
         3.4335554553543783,
         -9.8965831153747,
         -1.4568043853617796,
@@ -1795,7 +1795,7 @@ def test_13Node_Lines(dss):
         2.0889991803940724,
         2.658753201413196,
         -8.847115639537611,
-    ]
+    ])
     with pt.raises(dss.DSSException):
         # This is not allowed at the moment (the value is/was ignored before)
         # so an exception was added in case someone was trying to use it
@@ -1803,7 +1803,7 @@ def test_13Node_Lines(dss):
 
     assert dss.Lines.R0() == 3.378880258497484e-05
     assert dss.Lines.X0() == 7.664982290436836e-05
-    assert dss.Lines.RMatrix() == [
+    np.testing.assert_array_almost_equal(dss.Lines.RMatrix(), [
         6.562679425837321e-05,
         2.9546262350090106e-05,
         2.992506058534767e-05,
@@ -1813,8 +1813,8 @@ def test_13Node_Lines(dss):
         2.992506058534767e-05,
         2.9072764556018148e-05,
         6.466085875846642e-05,
-    ]
-    assert dss.Lines.XMatrix() == [
+    ])
+    np.testing.assert_array_almost_equal(dss.Lines.XMatrix(), [
         0.00019278936183433795,
         9.502153731436029e-05,
         8.022946622755235e-05,
@@ -1824,7 +1824,7 @@ def test_13Node_Lines(dss):
         8.022946622755235e-05,
         7.289972037531847e-05,
         0.00019599020692226434,
-    ]
+    ])
 
     assert dss.Lines.R1() == 1.0985148822469399e-05
     assert dss.Lines.X1() == 2.2841533586031195e-05
@@ -1832,7 +1832,7 @@ def test_13Node_Lines(dss):
 
 def test_13Node_Loads(dss):
 
-    assert dss.Loads.AllNames() == [
+    np.testing.assert_array_equal(dss.Loads.AllNames(), [
         u"671",
         u"634a",
         u"634b",
@@ -1848,7 +1848,7 @@ def test_13Node_Loads(dss):
         u"670a",
         u"670b",
         u"670c",
-    ]
+    ])
     assert dss.Loads.AllocationFactor() == 0.5
     assert dss.Loads.CFactor() == 4.0
     assert dss.Loads.CVRCurve() == u""
@@ -1880,7 +1880,7 @@ def test_13Node_Loads(dss):
     assert dss.Loads.XfkVA() == 0.0
     assert dss.Loads.Xneut() == 0.0
     assert dss.Loads.Yearly() == u""
-    assert dss.Loads.ZipV() == []
+    np.testing.assert_array_almost_equal(dss.Loads.ZipV(), [])
     assert dss.Loads.kV() == 0.277
     assert dss.Loads.kVABase() == 194.164878389476
     assert dss.Loads.kW() == 160.0
@@ -1891,7 +1891,7 @@ def test_13Node_Loads(dss):
 
 
 def test_13Node_LoadShape(dss):
-    assert dss.LoadShape.AllNames() == [u"default"]
+    np.testing.assert_array_equal(dss.LoadShape.AllNames(), [u"default"])
     assert dss.LoadShape.Count() == 1
     assert dss.LoadShape.First() == 1
     assert dss.LoadShape.HrInterval() == 1.0
@@ -1901,7 +1901,7 @@ def test_13Node_LoadShape(dss):
     assert dss.LoadShape.Normalize() is None
     assert dss.LoadShape.Npts() == 24
     assert dss.LoadShape.PBase() == 0.0
-    assert dss.LoadShape.PMult() == [
+    np.testing.assert_array_almost_equal(dss.LoadShape.PMult(), [
         0.677,
         0.6256,
         0.6087,
@@ -1926,21 +1926,21 @@ def test_13Node_LoadShape(dss):
         0.876,
         0.828,
         0.756,
-    ]
+    ])
     assert dss.LoadShape.QBase() == 0.0
-    assert dss.LoadShape.QMult() == [0.0]
+    np.testing.assert_array_almost_equal(dss.LoadShape.QMult(), [0.0])
     assert dss.LoadShape.SInterval() == 3600.0
-    assert dss.LoadShape.TimeArray() == [0.0]
+    np.testing.assert_array_almost_equal(dss.LoadShape.TimeArray(), [0.0])
     assert dss.LoadShape.UseActual() == 0
 
 
 def test_13Node_Meters(dss):
-    assert dss.Meters.AllBranchesInZone() == []
-    assert dss.Meters.AllEndElements() == []
-    assert dss.Meters.AllNames() == []
-    assert dss.Meters.AllocFactors() == [0.0]
-    assert dss.Meters.AvgRepairTime() == 0.0
-    assert dss.Meters.CalcCurrent() == [0.0]
+    np.testing.assert_array_almost_equal(dss.Meters.AllBranchesInZone(), [])
+    np.testing.assert_array_almost_equal(dss.Meters.AllEndElements(), [])
+    np.testing.assert_array_equal(dss.Meters.AllNames(), [])
+    np.testing.assert_array_almost_equal(dss.Meters.AllocFactors(), [0.0])
+    np.testing.assert_array_almost_equal(dss.Meters.AvgRepairTime(), 0.0)
+    np.testing.assert_array_almost_equal(dss.Meters.CalcCurrent(), [0.0])
     assert dss.Meters.CloseAllDIFiles() is None
     assert dss.Meters.Count() == 0
     assert dss.Meters.CountBranches() == 0
@@ -1958,9 +1958,9 @@ def test_13Node_Meters(dss):
     assert dss.Meters.NumSections() == 0
     assert dss.Meters.OCPDeviceType() == 0
     assert dss.Meters.OpenAllDIFiles() is None
-    assert dss.Meters.PeakCurrent() == [0.0]
-    assert dss.Meters.RegisterNames() == []
-    assert dss.Meters.RegisterValues() == [0.0]
+    np.testing.assert_array_almost_equal(dss.Meters.PeakCurrent(), [0.0])
+    np.testing.assert_array_almost_equal(dss.Meters.RegisterNames(), [])
+    np.testing.assert_array_almost_equal(dss.Meters.RegisterValues(), [0.0])
     assert dss.Meters.Reset() is None
     assert dss.Meters.ResetAll() is None
     assert dss.Meters.SAIDI() == 0.0
@@ -1977,7 +1977,7 @@ def test_13Node_Meters(dss):
     assert dss.Meters.SetActiveSection(0) is None
     assert dss.Meters.SumBranchFltRates() == 0.0
     assert dss.Meters.TotalCustomers() == 0
-    assert dss.Meters.Totals() == [
+    np.testing.assert_array_almost_equal(dss.Meters.Totals(), [
         0.0,
         0.0,
         0.0,
@@ -2045,12 +2045,12 @@ def test_13Node_Meters(dss):
         0.0,
         0.0,
         0.0,
-    ]
+    ])
 
 
 def test_13Node_Monitors(dss):
-    assert dss.Monitors.AllNames() == []
-    assert dss.Monitors.ByteStream() == []
+    np.testing.assert_array_equal(dss.Monitors.AllNames(), [])
+    np.testing.assert_array_almost_equal(dss.Monitors.ByteStream(), [])
     assert dss.Monitors.Count() == 0
     assert dss.Monitors.Element() == u"0"
     assert dss.Monitors.FileName() == u""
@@ -2117,7 +2117,7 @@ def test_13Node_PVsystems(dss):
 
 
 def test_13Node_Reclosers(dss):
-    assert dss.Reclosers.AllNames() == []
+    np.testing.assert_array_equal(dss.Reclosers.AllNames(), [])
     assert dss.Reclosers.Close() is None
     assert dss.Reclosers.Count() == 0
     assert dss.Reclosers.First() == 0
@@ -2132,7 +2132,7 @@ def test_13Node_Reclosers(dss):
     assert dss.Reclosers.Open() is None
     assert dss.Reclosers.PhaseInst() == 0.0
     assert dss.Reclosers.PhaseTrip() == 0.0
-    assert dss.Reclosers.RecloseIntervals() == [-1.0]
+    np.testing.assert_array_almost_equal(dss.Reclosers.RecloseIntervals(), [-1.0])
     assert dss.Reclosers.Shots() == 0
     assert dss.Reclosers.SwitchedObj() == u""
     assert dss.Reclosers.SwitchedTerm() == 0
@@ -2140,7 +2140,7 @@ def test_13Node_Reclosers(dss):
 
 def test_13Node_RegControls(dss):
 
-    assert dss.RegControls.AllNames() == [u"reg1", u"reg2", u"reg3"]
+    np.testing.assert_array_equal(dss.RegControls.AllNames(), [u"reg1", u"reg2", u"reg3"])
     assert dss.RegControls.CTPrimary() == 700.0
     assert dss.RegControls.Count() == 3
     assert dss.RegControls.Delay() == 15.0
@@ -2170,7 +2170,7 @@ def test_13Node_RegControls(dss):
 
 def test_13Node_Relays(dss):
 
-    assert dss.Relays.AllNames() == []
+    np.testing.assert_array_equal(dss.Relays.AllNames(), [])
     assert dss.Relays.Count() == 0
     assert dss.Relays.First() == 0
     assert dss.Relays.Idx() == 0
@@ -2183,9 +2183,9 @@ def test_13Node_Relays(dss):
 
 
 def test_13Node_Sensors(dss):
-    assert dss.Sensors.AllNames() == []
+    np.testing.assert_array_equal(dss.Sensors.AllNames(), [])
     assert dss.Sensors.Count() == 0
-    assert dss.Sensors.Currents() == [0.0]
+    np.testing.assert_array_almost_equal(dss.Sensors.Currents(), [0.0])
     assert dss.Sensors.First() == 0
     assert dss.Sensors.IsDelta() == 0
     assert dss.Sensors.MeteredElement() == u""
@@ -2198,8 +2198,8 @@ def test_13Node_Sensors(dss):
     assert dss.Sensors.ReverseDelta() == 0
     assert dss.Sensors.Weight() == 0.0
     assert dss.Sensors.kVBase() == 0.0
-    assert dss.Sensors.kW() == [0.0]
-    assert dss.Sensors.kvar() == [0.0]
+    np.testing.assert_array_almost_equal(dss.Sensors.kW(), [0.0])
+    np.testing.assert_array_almost_equal(dss.Sensors.kvar(), [0.0])
 
 
 def test_13Node_Settings(dss):
@@ -2216,16 +2216,16 @@ def test_13Node_Settings(dss):
 
     assert dss.Settings.EmergVmaxpu() == 1.08
     assert dss.Settings.EmergVminpu() == 0.9
-    assert dss.Settings.LossRegs() == [13]
+    np.testing.assert_array_equal(dss.Settings.LossRegs(), [13])
     assert dss.Settings.LossWeight() == 1.0
     assert dss.Settings.NormVmaxpu() == 1.05
     assert dss.Settings.NormVminpu() == 0.95
     assert dss.Settings.PriceCurve() == u""
     assert dss.Settings.PriceSignal() == 25.0
     assert dss.Settings.Trapezoidal() == 0
-    assert dss.Settings.UERegs() == [10]
+    np.testing.assert_array_equal(dss.Settings.UERegs(), [10])
     assert dss.Settings.UEWeight() == 1.0
-    assert dss.Settings.VoltageBases() == [115.0, 4.16, 0.48]
+    np.testing.assert_array_equal(dss.Settings.VoltageBases(), [115.0, 4.16, 0.48])
     assert dss.Settings.ZoneLock() == 0
 
 
@@ -2245,14 +2245,14 @@ def test_13Node_Solution(dss):
     assert dss.Solution.DefaultDaily() == u"default"
     assert dss.Solution.DefaultYearly() == u"default"
     assert dss.Solution.DoControlActions() is None
-    assert dss.Solution.EventLog() == [
+    np.testing.assert_array_equal(dss.Solution.EventLog(), [
         u"Hour=0, Sec=0, ControlIter=1, Element=Regulator.reg3, Action= CHANGED 7 TAPS TO 1.04375.",
         u"Hour=0, Sec=0, ControlIter=1, Element=Regulator.reg2, Action= CHANGED 5 TAPS TO 1.03125.",
         u"Hour=0, Sec=0, ControlIter=1, Element=Regulator.reg1, Action= CHANGED 7 TAPS TO 1.04375.",
         u"Hour=0, Sec=0, ControlIter=2, Element=Regulator.reg3, Action= CHANGED 2 TAPS TO 1.05625.",
         u"Hour=0, Sec=0, ControlIter=2, Element=Regulator.reg2, Action= CHANGED 1 TAPS TO 1.0375.",
         u"Hour=0, Sec=0, ControlIter=2, Element=Regulator.reg1, Action= CHANGED 2 TAPS TO 1.05625.",
-    ]
+    ])
     assert dss.Solution.FinishTimeStep() is None
     assert dss.Solution.Frequency() == 60.0
     assert dss.Solution.GenMult() == 1.0
@@ -2291,7 +2291,7 @@ def test_13Node_Solution(dss):
 
 def test_13Node_SwtControls(dss):
     assert dss.SwtControls.Action() == 0
-    assert dss.SwtControls.AllNames() == []
+    np.testing.assert_array_equal(dss.SwtControls.AllNames(), [])
     assert dss.SwtControls.Count() == 0
     assert dss.SwtControls.Delay() == 0.0
     assert dss.SwtControls.First() == 0
@@ -2305,16 +2305,16 @@ def test_13Node_SwtControls(dss):
 def test_13Node_Topology(dss):
     assert dss.Topology.ActiveBranch() == 0
     assert dss.Topology.ActiveLevel() == 0
-    assert dss.Topology.AllIsolatedBranches() == []
-    assert dss.Topology.AllIsolatedLoads() == []
-    assert dss.Topology.AllLoopedPairs() == [
+    np.testing.assert_array_almost_equal(dss.Topology.AllIsolatedBranches(), [])
+    np.testing.assert_array_almost_equal(dss.Topology.AllIsolatedLoads(), [])
+    np.testing.assert_array_equal(dss.Topology.AllLoopedPairs(), [
         u"Transformer.reg3",
         u"Transformer.reg2",
         u"Transformer.reg2",
         u"Line.650632",
         u"Transformer.reg1",
         u"Line.650632",
-    ]
+    ])
     assert dss.Topology.BranchName() == u""
     assert dss.Topology.BusName() == u""
     assert dss.Topology.First() == 1
@@ -2330,7 +2330,7 @@ def test_13Node_Topology(dss):
 
 
 def test_13Node_Transformers(dss):
-    assert dss.Transformers.AllNames() == [u"sub", u"reg1", u"reg2", u"reg3", u"xfm1"]
+    np.testing.assert_array_equal(dss.Transformers.AllNames(), [u"sub", u"reg1", u"reg2", u"reg3", u"xfm1"])
     assert dss.Transformers.Count() == 5
     assert dss.Transformers.First() == 1
     assert dss.Transformers.IsDelta() == 0
@@ -2354,7 +2354,7 @@ def test_13Node_Transformers(dss):
 
 
 def test_13Node_Vsources(dss):
-    assert dss.Vsources.AllNames() == [u"source"]
+    np.testing.assert_array_equal(dss.Vsources.AllNames(), [u"source"])
     assert dss.Vsources.AngleDeg() == 30.0
     assert dss.Vsources.BasekV() == 115.0
     assert dss.Vsources.Count() == 1
@@ -2380,8 +2380,8 @@ def test_13Node_XYCurves(dss):
     with pt.raises(dss.DSSException):
         dss.XYCurves.XScale()
 
-    assert dss.XYCurves.XArray() == [0.0]
-    assert dss.XYCurves.YArray() == [0.0]
+    np.testing.assert_array_almost_equal(dss.XYCurves.XArray(), [0.0])
+    np.testing.assert_array_almost_equal(dss.XYCurves.YArray(), [0.0])
 
 
 def test_capacitors_to_dataframe(dss):


### PR DESCRIPTION
There's some interest in doing some performance benchmarks when using OpenDSSDirect.py. I've set up a branch where people can toggle the numpy version using an environment variable. @PMeira, what do you think?