### PR TITLE
Fix units for TotalPower

### DIFF
--- a/opendssdirect/Circuit.py
+++ b/opendssdirect/Circuit.py
@@ -205,7 +205,7 @@ def SystemY():
 
 
 def TotalPower():
-    """(read-only) Total power, watts delivered to the circuit"""
+    """(read-only) Total power, kw delivered to the circuit"""
     return get_float64_array(lib.Circuit_Get_TotalPower)
 
 


### PR DESCRIPTION
`Circuit.TotalPower` eventually calls `procedure Circuit_Get_TotalPower(var ResultPtr: PDouble; ResultCount: PAPISize); CDECL;` which is in kW:

https://github.com/dss-extensions/dss_capi/blob/a1be467609314cb4d5b164c3e088591a9fa25567/src/CAPI/CAPI_Circuit.pas#L325

Thanks @daniel-thom for reporting.


